### PR TITLE
Move bird in login navbar

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -21,3 +21,8 @@
 .ResponsiveLayout {
 	padding-top: 40px !important;
 }
+
+/* bird overlaps with the login navbar */
+img.larrybird {
+	padding-left: 80px !important;
+}


### PR DESCRIPTION
I did this because the twitter logo overlapped w/ traffic sign buttons.
