### PR TITLE
Add extra vim bindings

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -25,8 +25,10 @@ const remote = electron.remote;
 const path = remote.require('path');
 const storage = remote.require('./storage');
 const $ = document.querySelector.bind(document);
-const scrollStep = 50;
 // const $$ = document.querySelectorAll.bind(document);
+
+const scrollStep = 50;
+const pageScrollPctHeight = 0.9;
 
 function changeTab(next) {
 	const pages = [
@@ -102,11 +104,11 @@ function registerShortcuts(username) {
 	});
 
 	Mousetrap.bind('ctrl+d', () => {
-		scrollToY(fromScrollTop(window.innerHeight * 0.9));
+		scrollToY(fromScrollTop(window.innerHeight * pageScrollPctHeight));
 	});
 
 	Mousetrap.bind('ctrl+u', () => {
-		scrollToY(fromScrollTop(window.innerHeight * -0.9));
+		scrollToY(fromScrollTop(window.innerHeight * -pageScrollPctHeight));
 	});
 
 	Mousetrap.bind('G', () => {

--- a/browser.js
+++ b/browser.js
@@ -25,6 +25,7 @@ const remote = electron.remote;
 const path = remote.require('path');
 const storage = remote.require('./storage');
 const $ = document.querySelector.bind(document);
+const scrollStep = 50;
 // const $$ = document.querySelectorAll.bind(document);
 
 function changeTab(next) {
@@ -49,6 +50,10 @@ ipc.on('next-tab', () => {
 ipc.on('previous-tab', () => {
 	changeTab(false);
 });
+
+function fromScrollTop(n) {
+	return document.body.scrollTop + n;
+}
 
 function registerShortcuts(username) {
 	Mousetrap.bind('n', () => {
@@ -77,6 +82,31 @@ function registerShortcuts(username) {
 		$('a[href$="/search"]').click();
 
 		return false;
+	});
+
+	// vim bindings
+	Mousetrap.bind('j', () => {
+		window.scrollTo(0, fromScrollTop(scrollStep));
+	});
+
+	Mousetrap.bind('k', () => {
+		window.scrollTo(0, fromScrollTop((scrollStep * -1)));
+	});
+
+	Mousetrap.bind('g g', () => {
+		window.scrollTo(0, 0);
+	});
+
+	Mousetrap.bind('ctrl+d', () => {
+		window.scrollTo(0, fromScrollTop(window.innerHeight * 0.9));
+	});
+
+	Mousetrap.bind('ctrl+u', () => {
+		window.scrollTo(0, fromScrollTop(window.innerHeight * -0.9));
+	});
+
+	Mousetrap.bind('G', () => {
+		window.scrollTo(0, document.body.scrollHeight);
 	});
 
 	Mousetrap.bind('g p', () => {

--- a/browser.js
+++ b/browser.js
@@ -55,6 +55,10 @@ function fromScrollTop(n) {
 	return document.body.scrollTop + n;
 }
 
+function scrollToY(y) {
+	return window.scrollTo(0, y);
+}
+
 function registerShortcuts(username) {
 	Mousetrap.bind('n', () => {
 		if (window.location.pathname.split('/')[1] === 'messages') {
@@ -86,27 +90,27 @@ function registerShortcuts(username) {
 
 	// vim bindings
 	Mousetrap.bind('j', () => {
-		window.scrollTo(0, fromScrollTop(scrollStep));
+		scrollToY(fromScrollTop(scrollStep));
 	});
 
 	Mousetrap.bind('k', () => {
-		window.scrollTo(0, fromScrollTop((scrollStep * -1)));
+		scrollToY(fromScrollTop(scrollStep * -1));
 	});
 
 	Mousetrap.bind('g g', () => {
-		window.scrollTo(0, 0);
+		scrollToY(0);
 	});
 
 	Mousetrap.bind('ctrl+d', () => {
-		window.scrollTo(0, fromScrollTop(window.innerHeight * 0.9));
+		scrollToY(fromScrollTop(window.innerHeight * 0.9));
 	});
 
 	Mousetrap.bind('ctrl+u', () => {
-		window.scrollTo(0, fromScrollTop(window.innerHeight * -0.9));
+		scrollToY(fromScrollTop(window.innerHeight * -0.9));
 	});
 
 	Mousetrap.bind('G', () => {
-		window.scrollTo(0, document.body.scrollHeight);
+		scrollToY(document.body.scrollHeight);
 	});
 
 	Mousetrap.bind('g p', () => {

--- a/readme.md
+++ b/readme.md
@@ -59,6 +59,12 @@ Icon=/full/path/to/folder/Anatine/resources/app/media/Icon.png
 - Go to previous page: <kbd>Delete</kbd> or <kbd>Backspace</kbd>
 - Next tab: <kbd>Ctrl</kbd> <kbd>Tab</kbd>
 - Previous tab: <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>Tab</kbd>
+- Scroll up: <kbd>k</kbd>
+- Scroll down: <kbd>j</kbd>
+- Page down: <kbd>Ctrl</kbd> <kbd>d</kbd>
+- Page up: <kbd>Ctrl</kbd> <kbd>u</kbd>
+- Scroll to top: <kbd>g</kbd> <kbd>g</kbd>
+- Scroll to bottom: <kbd>G</kbd>
 
 
 ## Dev


### PR DESCRIPTION
Excellent little app. This change adds the following vi-like scroll bindings, as explained in the readme:
- Scroll up: <kbd>k</kbd>
- Scroll down: <kbd>j</kbd>
- Page down: <kbd>Ctrl</kbd> <kbd>d</kbd>
- Page up: <kbd>Ctrl</kbd> <kbd>u</kbd>
- Scroll to top: <kbd>g</kbd> <kbd>g</kbd>
- Scroll to bottom: <kbd>G</kbd>
