### PR TITLE
Fix extra whitespace below header when using vim keys

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -26,17 +26,19 @@ Updates should happen there first.
 */
 const scrollToTweet = event => { // eslint-disable-line
 	const $ = document.querySelector.bind(document);
-	const navHeight = $('nav').clientHeight;
 	const tweets = document.querySelectorAll('._222QxFjc[role="row"]');
 	const currentTop = window.scrollY;
 	const bufferTop = 5; // added because somtimes the scrolling is off by a few px
 	const keyCode = event.charCode; // TODO: replace with key when Chrome 51 is out https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key
 
+	// calculate the height of the navigation/header to use for scrolling
+	const calculatedNavHeight = $('header').clientHeight + ($('header').clientHeight - $('nav').clientHeight);
+
 	// this padding has to be applied to factor in the padding that's added to the container
 	const tweetsContainerPadding = Math.ceil(parseInt($('._1nQuzuNK').style.paddingTop.replace('px', ''), 10));
 
 	// shortcut for getting the total offset from the top of the document of a particular tweet
-	const totalOffset = tweetOffset => tweetOffset + navHeight + tweetsContainerPadding;
+	const totalOffset = tweetOffset => tweetOffset + calculatedNavHeight + tweetsContainerPadding;
 
 	// takes a tweet's offsetTop and checks if it's below the navigation bar
 	const tweetIsBelowNav = offset => totalOffset(offset) > currentTop + bufferTop;


### PR DESCRIPTION
In the web version, the `header` element is the same height as the `nav` element. In Anatine, the header is larger and creates a white space below the nav. We have to scroll as far as the header _and then the difference between those elements_ to make up for that extra space so the top of the tweet matches the bottom of the `nav`.

![dexter-showtime-UwNNlubSCsWLS](https://camo.githubusercontent.com/975c2b7af31e1cdec6a5d43ff2ec7c76f8d76419/68747470733a2f2f6d65646961342e67697068792e636f6d2f6d656469612f55774e4e6c7562534373574c532f67697068792e676966)
