### PR TITLE
added cmd+n hotkey.

### DIFF
--- a/menu.js
+++ b/menu.js
@@ -142,6 +142,7 @@ const darwinTpl = [
 		submenu: [
 			{
 				label: 'New Tweet',
+				accelerator: 'Cmd+N',
 				click() {
 					sendAction('new-tweet');
 				}


### PR DESCRIPTION
When cloning the repo, i realized the readme stated the n button for doing a new tweet, along with other hotkeys. Though I still found it odd New Tweet was in the app menu without a hotkey, so I added one. Especially coming from the mac twitter client, this feels more natural to me. Up to you if you think it's worth while or not.
