### PR TITLE
'use strict'

### DIFF
--- a/tray.js
+++ b/tray.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const path = require('path');
 const electron = require('electron');
 const app = electron.app;


### PR DESCRIPTION
missing 'use strict' causing problem for older version of node.

![screenshot from 2016-05-13 02 16 57](https://cloud.githubusercontent.com/assets/9411252/15229922/ce811080-18b0-11e6-9b29-32f33ad96511.png)
