### PR TITLE
Use clearInterval to wait for React before init

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -98,27 +98,35 @@ function changeTab(next) {
 	$(`a[href$="${pages[ret]}"]`).click();
 }
 
+// sets interval to wait for selector to be ready before firing callback
+function waitFor(selectorString, callback) {
+	const awaitReact = setInterval(() => {
+		if ($(selectorString)) {
+			callback();
+			clearInterval(awaitReact);
+			return;
+		}
+	}, 100);
+}
+
 function newTweet() {
 	if (window.location.pathname.split('/')[1] === 'messages') {
 		$('a[href$="/home"]').click();
-
-		// // TODO: improve the logic here and instead use an
-		// // interval to detect when the button is available
-		setTimeout(newTweet, 400);
-		return;
 	}
 
-	$('a[href$="/compose/tweet"]').click();
+	// wait for new tweet button to click it
+	waitFor('a[href$="/compose/tweet"]', () => {
+		$('a[href$="/compose/tweet"]').click();
+	});
 }
 
 function newDM() {
 	$('a[href$="/messages"]').click();
 
-	// TODO: improve the logic here and instead use an
-	// interval to detect when the button is available
-	setTimeout(() => {
+	// wait for new message button to click it
+	waitFor('a[href$="/messages/compose"]', () => {
 		$('a[href$="/messages/compose"]').click();
-	}, 1000);
+	});
 }
 
 ipc.on('next-tab', () => {
@@ -308,6 +316,6 @@ document.addEventListener('DOMContentLoaded', () => {
 	// enable OS specific styles
 	document.documentElement.classList.add(`os-${process.platform}`);
 
-	// TODO: figure out a better way to detect when React is done
-	setTimeout(init, 300);
+	// detect when React is ready before firing init
+	waitFor('#react-root header', init);
 });

--- a/browser.js
+++ b/browser.js
@@ -99,14 +99,25 @@ function changeTab(next) {
 }
 
 // sets interval to wait for selector to be ready before firing callback
-function waitFor(selectorString, callback) {
-	const awaitReact = setInterval(() => {
-		if ($(selectorString)) {
-			callback();
-			clearInterval(awaitReact);
+function waitFor(selector) {
+	return new Promise(resolve => {
+		const el = $(selector);
+
+		// shortcut if the element already exists
+		if (el) {
+			resolve(el);
 			return;
 		}
-	}, 100);
+
+		// interval to keep checking for it to come into the DOM
+		const awaitElement = setInterval(() => {
+			const el = $(selector);
+			if (el) {
+				resolve(el);
+				clearInterval(awaitElement);
+			}
+		}, 50);
+	});
 }
 
 function newTweet() {
@@ -115,18 +126,14 @@ function newTweet() {
 	}
 
 	// wait for new tweet button to click it
-	waitFor('a[href$="/compose/tweet"]', () => {
-		$('a[href$="/compose/tweet"]').click();
-	});
+	waitFor('a[href$="/compose/tweet"]').then(element => element.click());
 }
 
 function newDM() {
 	$('a[href$="/messages"]').click();
 
 	// wait for new message button to click it
-	waitFor('a[href$="/messages/compose"]', () => {
-		$('a[href$="/messages/compose"]').click();
-	});
+	waitFor('a[href$="/messages/compose"]').then(element => element.click());
 }
 
 ipc.on('next-tab', () => {
@@ -317,5 +324,5 @@ document.addEventListener('DOMContentLoaded', () => {
 	document.documentElement.classList.add(`os-${process.platform}`);
 
 	// detect when React is ready before firing init
-	waitFor('#react-root header', init);
+	waitFor('#react-root header').then(init);
 });


### PR DESCRIPTION
This is a super simple solution to waiting for React before firing the `init` function. Since the `init` only really depends on the `header` element, we're waiting on that to load into the DOM.

This fixes #15.

// @sindresorhus   
