### PR TITLE
Hide nav profile with CSS instead - fix #40

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -16,6 +16,11 @@ html.os-win32 #react-root header .WBlUyLoP {
 	width: 80% !important;
 }
 
+/* hide profile in navbar */
+._1dNhc0QK > ._3tixQkQf:last-of-type {
+	display: none;
+}
+
 /* main */
 #react-root main .WBlUyLoP {
 	max-width: 90% !important;

--- a/browser.js
+++ b/browser.js
@@ -232,9 +232,6 @@ if (process.platform === 'darwin') {
 }
 
 function init() {
-	// hide navbar profile link
-	$('header a[href$="/account"]').parentNode.style.display = 'none';
-
 	const state = JSON.parse($('.___iso-state___').dataset.state).initialState;
 	const username = state.settings.data.screen_name;
 


### PR DESCRIPTION
This is a fix for #40.

This changes the method for hiding the profile in the nav to using CSS.
