### PR TITLE
Color links in tweets and embedded media BGs

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -62,6 +62,11 @@ html.dark-mode ._3EzK97M9 > span {
 	color: rgba(255, 255, 255, 0.75);
 }
 
+/* tweet links are spans in spans in spans */
+html.dark-mode ._3ZFqFXW8 ._3EzK97M9 > span > span {
+	color: #2AA2EF !important;
+}
+
 /* user "real name" */
 html.dark-mode ._38kXZCmY,
 /* follower counts */
@@ -89,10 +94,11 @@ html.dark-mode ._1jtqWh_6 {
 	background-color: rgba(255, 255, 255, 0.4) !important;
 }
 
-/* embedded media border colour */
+/* embedded media border colour and background */
 html.dark-mode ._1K1FePxK,
 html.dark-mode .zLkZvTFz,
 html.dark-mode ._1unhGaVg {
+	background-color: #2A3D51 !important;
 	border-color: rgba(255, 255, 255, 0.1);
 }
 


### PR DESCRIPTION
This is a fixes #44.

I'm not sure I got the colors right, so if I need to change them just provide the hex/rgba.

![screen shot 2016-05-14 at 8 57 38 pm](https://cloud.githubusercontent.com/assets/737065/15271453/43b658ca-1a18-11e6-895e-7c4a5a1fbd4f.png)

![screen shot 2016-05-14 at 9 06 30 pm](https://cloud.githubusercontent.com/assets/737065/15271454/43b80292-1a18-11e6-9482-63e3c627dc28.png)

Looks even nicer in the notifications view!
