### PR TITLE
Hide 'Your tweet was posted' message

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -92,3 +92,8 @@ html:-webkit-any(.os-linux, .os-win32) ::-webkit-scrollbar-thumb {
 	border-radius: 2px;
 	-webkit-box-shadow: inset 0 0 3px rgba(0,0,0,0.3);
 }
+
+/* hide "your tweet was posted" message */
+._1aaIXoeM.mqmxGGg7._3tixQkQf {
+	display: none !important;
+}


### PR DESCRIPTION
As requested here: https://github.com/sindresorhus/refined-twitter/commit/6177414a3aab6e91b1bdea483c16d10f9b07f56c#commitcomment-17485468

This hides the message "Your tweet was posted" when you send a new tweet.
