### PR TITLE
Persist dark mode independent of system settings - fix #34

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -78,7 +78,6 @@ const scrollToTweet = event => { // eslint-disable-line
 const electron = require('electron');
 const ipc = electron.ipcRenderer;
 const remote = electron.remote;
-const osxAppearance = require('electron-osx-appearance');
 const storage = remote.require('./storage');
 const $ = document.querySelector.bind(document);
 // const $$ = document.querySelectorAll.bind(document);
@@ -241,21 +240,9 @@ ipc.on('toggle-dark-mode', () => {
 	setDarkMode();
 });
 
-if (process.platform === 'darwin') {
-	osxAppearance.onDarkModeChanged(() => {
-		storage.set('darkMode', osxAppearance.isDarkMode());
-		setDarkMode();
-	});
-}
-
 function init() {
 	const state = JSON.parse($('.___iso-state___').dataset.state).initialState;
 	const username = state.settings.data.screen_name;
-
-	// link the theme if it was changed while the app was closed
-	if (process.platform === 'darwin') {
-		storage.set('darkMode', osxAppearance.isDarkMode());
-	}
 
 	// activate Dark Mode if it was set before quitting
 	setDarkMode();

--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "electron-debug": "^1.0.0",
-    "electron-dl": "^1.0.0",
-    "electron-osx-appearance": "^0.1.1"
+    "electron-dl": "^1.0.0"
   },
   "devDependencies": {
     "electron-packager": "^7.0.0",


### PR DESCRIPTION
This is a fix for #34 and an alternative solution to #35. There are differences to the end result between this and #35:

In this change only the `anatine` settings are used to determine if the app is in `darkMode` or not. The OSX system settings for Dark Mode can be toggled independently and the app will retain the last state.

// @SamVerschueren @danhp @tandrewnichols        
