### PR TITLE
Add max-width to window and container - fix #47

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -11,13 +11,13 @@ html.os-win32 {
 
 /* navbar */
 html.os-darwin #react-root header .WBlUyLoP {
-	max-width: 60% !important;
+	max-width: 800px !important;
 	width: 60% !important;
 }
 html.os-linux #react-root header .WBlUyLoP,
 html.os-win32 #react-root header .WBlUyLoP {
 	/* wider on Linux and Windows since they don't have the traffic lights */
-	max-width: 80% !important;
+	max-width: 800px !important;
 	width: 80% !important;
 }
 
@@ -28,7 +28,7 @@ html.os-win32 #react-root header .WBlUyLoP {
 
 /* main */
 #react-root main .WBlUyLoP {
-	max-width: 90% !important;
+	max-width: 800px !important;
 	width: 90% !important;
 }
 

--- a/index.js
+++ b/index.js
@@ -74,6 +74,14 @@ function createMainWindow() {
 		e.preventDefault();
 	});
 
+	win.on('enter-full-screen', () => {
+		win.setMaximumSize(2147483647, 2147483647);
+	});
+
+	win.on('leave-full-screen', () => {
+		win.setMaximumSize(850, 2147483647);
+	});
+
 	return win;
 }
 

--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ function createMainWindow() {
 		height: lastWindowState.height,
 		icon: process.platform === 'linux' && path.join(__dirname, 'static/Icon.png'),
 		minWidth: 340,
+		maxWidth: 850,
 		minHeight: 260,
 		titleBarStyle: 'hidden-inset',
 		autoHideMenuBar: true,

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ if (isAlreadyRunning) {
 
 function createMainWindow() {
 	const lastWindowState = storage.get('lastWindowState') || {width: 500, height: 600};
+	const maxWindowInteger = 2147483647; // used to set max window width/height when toggling fullscreen
 
 	const win = new electron.BrowserWindow({
 		title: app.getName(),
@@ -75,11 +76,11 @@ function createMainWindow() {
 	});
 
 	win.on('enter-full-screen', () => {
-		win.setMaximumSize(2147483647, 2147483647);
+		win.setMaximumSize(maxWindowInteger, maxWindowInteger);
 	});
 
 	win.on('leave-full-screen', () => {
-		win.setMaximumSize(850, 2147483647);
+		win.setMaximumSize(850, maxWindowInteger);
 	});
 
 	return win;

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ if (isAlreadyRunning) {
 function createMainWindow() {
 	const lastWindowState = storage.get('lastWindowState') || {width: 500, height: 600};
 	const maxWindowInteger = 2147483647; // used to set max window width/height when toggling fullscreen
+	const maxWidthValue = 850;
 
 	const win = new electron.BrowserWindow({
 		title: app.getName(),
@@ -40,7 +41,7 @@ function createMainWindow() {
 		height: lastWindowState.height,
 		icon: process.platform === 'linux' && path.join(__dirname, 'static/Icon.png'),
 		minWidth: 340,
-		maxWidth: 850,
+		maxWidth: maxWidthValue,
 		minHeight: 260,
 		titleBarStyle: 'hidden-inset',
 		autoHideMenuBar: true,
@@ -80,7 +81,7 @@ function createMainWindow() {
 	});
 
 	win.on('leave-full-screen', () => {
-		win.setMaximumSize(850, maxWindowInteger);
+		win.setMaximumSize(maxWidthValue, maxWindowInteger);
 	});
 
 	return win;


### PR DESCRIPTION
This is a fix for #47, but I'm not super happy with it.

Because of the `maxWidth` on the window, the fullscreen version has these super ugly black bars.

![screen shot 2016-05-19 at 10 26 44 am](https://cloud.githubusercontent.com/assets/737065/15396941/3d65cbee-1dac-11e6-8c7a-8844d3806f4a.png)
