### PR TITLE
Fix BG on user avatars

### DIFF
--- a/dark-mode.css
+++ b/dark-mode.css
@@ -15,6 +15,8 @@ html.dark-mode ._3o5W64B2,
 html.dark-mode ._2fklWv1X,
 /* suggested people */
 html.dark-mode .mqmxGGg7,
+/* user avatars */
+html.dark-mode img._3uSDkk5s,
 /* comment section */
 html.dark-mode ._1R-qbptt {
 	background: #192633 !important;


### PR DESCRIPTION
It's nearly imperceptible, but in dark mode if a user avatar is not the right size you can see a BG bleeding out from the back of the image. This fixes that issue.

Before:
![screen shot 2016-05-19 at 10 29 11 am](https://cloud.githubusercontent.com/assets/737065/15397072/c1e43d9c-1dac-11e6-95cc-5c20d42081fb.png)

After:
![screen shot 2016-05-19 at 10 29 34 am](https://cloud.githubusercontent.com/assets/737065/15397078/c53b0e6c-1dac-11e6-801e-9ef6aa29ecff.png)
