### PR TITLE
Stop scrollbar at bottom of nav and style OSX scrollbar - fix #64

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -91,18 +91,33 @@ html.os-darwin #react-root ._246HcQqT {
 	width: 100%;
 }
 
-/* change scrollbar style */
+/* change scrollbar style for Linux/Windows */
 html:-webkit-any(.os-linux, .os-win32) ::-webkit-scrollbar {
 	width: 4px;
 }
 html:-webkit-any(.os-linux, .os-win32) ::-webkit-scrollbar-track {
 	-webkit-box-shadow: inset 0 0 3px rgba(0,0,0,0.3);
 	border-radius: 2px;
+	margin-top: 2.6rem;
 }
 html:-webkit-any(.os-linux, .os-win32) ::-webkit-scrollbar-thumb {
 	background: #444;
 	border-radius: 2px;
 	-webkit-box-shadow: inset 0 0 3px rgba(0,0,0,0.3);
+}
+
+html:-webkit-any(.os-darwin) ::-webkit-scrollbar {
+	width: 6px;
+}
+html:-webkit-any(.os-darwin) ::-webkit-scrollbar-track {
+	-webkit-border-radius: 6px;
+					border-radius: 6px;
+	margin-top: 2.6rem;
+}
+html:-webkit-any(.os-darwin) ::-webkit-scrollbar-thumb {
+	background: #7f7f7f;
+	-webkit-border-radius: 6px;
+					border-radius: 6px;
 }
 
 /* hide "your tweet was posted" message */


### PR DESCRIPTION
This does stop at the bottom of the `nav` now.

It looks like you can't just apply a style to the scrollbar track, so we'll have to style the scrollbar, track, and thumb at the very least. I didn't change the styles and simply removed the limitation to Linux and Windows, which changes the style for OSX. If we want to have the style for OSX match the system default I can update the PR with styles to (try to) match default.
