### PR TITLE
scrollbar does not expand to navbar - fixes #64

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -1,6 +1,7 @@
 /* default color */
 html {
 	background-color: #fff;
+	overflow: hidden;
 }
 
 /* make the navbar the windows's draggable region */
@@ -57,7 +58,8 @@ img.larrybird {
 }
 
 /* make nav bar more narrow */
-#react-root ._2XOZ62oy {
+#react-root ._2XOZ62oy,
+header[role="banner"] {
 	height: 2.6rem !important;
 }
 
@@ -129,4 +131,14 @@ html div._7xnAHtWH._3tixQkQf {
 	100% {
 		transform: rotate(360deg);
 	}
+}
+
+/* only make the main screen scrollable */
+main[role="main"] {
+	overflow: auto;
+	position: absolute;
+	top: 2.6rem;
+	left: 0px;
+	right: 0;
+	bottom: 0;
 }


### PR DESCRIPTION
When I tested it via `refined-twitter` in the browser, the infinite scrolling didn't work. I tried it again with `Anatine` now (see the changes), and apparently it is possible. Infinite scrolling works and the scrollbar does not expand to the navbar.

It does not seem to work on `refined-twitter` though.

![anatine](https://cloud.githubusercontent.com/assets/1913805/15552765/395685b0-22bc-11e6-884f-7d2c900edf7b.gif)
