### PR TITLE
Style login screen - fix #70

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -147,12 +147,12 @@ body.sessions-new-page .timeline-head {
 	background: inherit;
 }
 body.sessions-new-page .timeline-head:before {
-	background: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 273.4 222.2"><path fill="#55ACEE" d="M273.4 26.3c-10.1 4.5-20.9 7.5-32.2 8.8 11.6-6.9 20.5-17.9 24.7-31-10.9 6.4-22.9 11.1-35.7 13.6A55.92 55.92 0 0 0 189.3 0c-31 0-56.1 25.1-56.1 56.1 0 4.4.5 8.7 1.5 12.8C88 66.5 46.7 44.2 19 10.3c-4.8 8.3-7.6 17.9-7.6 28.2 0 19.5 9.9 36.6 25 46.7-9.2-.3-17.8-2.8-25.4-7v.7c0 27.2 19.3 49.8 45 55-4.7 1.3-9.7 2-14.8 2-3.6 0-7.1-.4-10.6-1 7.1 22.3 27.9 38.5 52.4 39-19.2 15-43.4 24-69.7 24-4.5 0-9-.3-13.4-.8 24.8 15.9 54.3 25.2 86 25.2 103.2 0 159.6-85.5 159.6-159.6 0-2.4-.1-4.9-.2-7.3 11.1-8 20.6-17.9 28.1-29.1z"/></svg>') no-repeat;
+	background: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 273.4 222.2"><path fill="#55ACEE" d="M273.4 26.3c-10.1 4.5-20.9 7.5-32.2 8.8 11.6-6.9 20.5-17.9 24.7-31-10.9 6.4-22.9 11.1-35.7 13.6A55.92 55.92 0 0 0 189.3 0c-31 0-56.1 25.1-56.1 56.1 0 4.4.5 8.7 1.5 12.8C88 66.5 46.7 44.2 19 10.3c-4.8 8.3-7.6 17.9-7.6 28.2 0 19.5 9.9 36.6 25 46.7-9.2-.3-17.8-2.8-25.4-7v.7c0 27.2 19.3 49.8 45 55-4.7 1.3-9.7 2-14.8 2-3.6 0-7.1-.4-10.6-1 7.1 22.3 27.9 38.5 52.4 39-19.2 15-43.4 24-69.7 24-4.5 0-9-.3-13.4-.8 24.8 15.9 54.3 25.2 86 25.2 103.2 0 159.6-85.5 159.6-159.6 0-2.4-.1-4.9-.2-7.3 11.1-8 20.6-17.9 28.1-29.1z"/></svg>') no-repeat;
 	content: ' ';
 	display: block;
 	width: 30px;
 	height: 30px;
-	margin: 0 auto;
+	margin: 2px auto 0 auto;
 }
 body.sessions-new-page .timeline-head a {
 	display: none;
@@ -184,6 +184,8 @@ body.sessions-new-page #main_content .signup-body form {
 body.sessions-new-page .inputs {
 	border: 1px solid #e8e8e8;
 	box-shadow: none;
+	margin-left: 30px;
+	margin-right: 30px;
 }
 
 /* hide links on login page */
@@ -193,6 +195,10 @@ body.sessions-new-page .signup-field-hint a:link {
 }
 
 /* login button on log in page */
+body.sessions-new-page .signup-button {
+	margin-left: 30px;
+	margin-right: 30px;
+}
 body.sessions-new-page .button.signup {
 	background-color: #2AA2EF;
 	background-image: none;

--- a/browser.css
+++ b/browser.css
@@ -137,8 +137,22 @@ body.sessions-new-page {
 	text-shadow: none !important;
 }
 
-/* hide header on login page */
+/* center header logo on login page */
 body.sessions-new-page .timeline-head {
+	min-width: 100%;
+	background-image: none;
+	background: inherit;
+}
+
+body.sessions-new-page .timeline-head a,
+body.sessions-new-page .timeline-head img.larrybird {
+	display: block;
+	margin: 0 auto;
+	padding: 0 !important;
+}
+
+/* hide header title on login page */
+body.sessions-new-page .timeline-head .title {
 	display: none;
 }
 

--- a/browser.css
+++ b/browser.css
@@ -137,17 +137,25 @@ body.sessions-new-page {
 	text-shadow: none !important;
 }
 
-/* center header logo on login page */
+/*
+ * center header logo on login page
+ * replace logo with SVG version
+ */
 body.sessions-new-page .timeline-head {
 	min-width: 100%;
 	background-image: none;
 	background: inherit;
 }
-body.sessions-new-page .timeline-head a,
-body.sessions-new-page .timeline-head img.larrybird {
+body.sessions-new-page .timeline-head:before {
+	background: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 273.4 222.2"><path fill="#55ACEE" d="M273.4 26.3c-10.1 4.5-20.9 7.5-32.2 8.8 11.6-6.9 20.5-17.9 24.7-31-10.9 6.4-22.9 11.1-35.7 13.6A55.92 55.92 0 0 0 189.3 0c-31 0-56.1 25.1-56.1 56.1 0 4.4.5 8.7 1.5 12.8C88 66.5 46.7 44.2 19 10.3c-4.8 8.3-7.6 17.9-7.6 28.2 0 19.5 9.9 36.6 25 46.7-9.2-.3-17.8-2.8-25.4-7v.7c0 27.2 19.3 49.8 45 55-4.7 1.3-9.7 2-14.8 2-3.6 0-7.1-.4-10.6-1 7.1 22.3 27.9 38.5 52.4 39-19.2 15-43.4 24-69.7 24-4.5 0-9-.3-13.4-.8 24.8 15.9 54.3 25.2 86 25.2 103.2 0 159.6-85.5 159.6-159.6 0-2.4-.1-4.9-.2-7.3 11.1-8 20.6-17.9 28.1-29.1z"/></svg>') no-repeat;
+	content: ' ';
 	display: block;
+	width: 30px;
+	height: 30px;
 	margin: 0 auto;
-	padding: 0 !important;
+}
+body.sessions-new-page .timeline-head a {
+	display: none;
 }
 
 /* hide header title on login page */

--- a/browser.css
+++ b/browser.css
@@ -143,7 +143,6 @@ body.sessions-new-page .timeline-head {
 	background-image: none;
 	background: inherit;
 }
-
 body.sessions-new-page .timeline-head a,
 body.sessions-new-page .timeline-head img.larrybird {
 	display: block;
@@ -161,7 +160,7 @@ body.sessions-new-page #main_content {
 	min-height: 100%;
 }
 
-/* vertically cetner login form */
+/* vertically center login form */
 body.sessions-new-page #main_content .signup-body {
 	position: absolute;
 	top: 50%;
@@ -169,9 +168,14 @@ body.sessions-new-page #main_content .signup-body {
 	bottom: 50%;
 	left: 0;
 }
-
 body.sessions-new-page #main_content .signup-body form {
 	transform: translateY(-50%);
+}
+
+/* change border on login form inputs */
+body.sessions-new-page .inputs {
+	border: 1px solid #e8e8e8;
+	box-shadow: none;
 }
 
 /* hide links on login page */

--- a/browser.css
+++ b/browser.css
@@ -130,3 +130,31 @@ html div._7xnAHtWH._3tixQkQf {
 		transform: rotate(360deg);
 	}
 }
+
+/* background of login page */
+body.sessions-new-page {
+	background: #fff;
+	text-shadow: none !important;
+}
+
+/* links on login page */
+body.sessions-new-page .signup-field-hint,
+body.sessions-new-page .signup-field-hint a:link {
+	color: #2AA2EF;
+	text-shadow: none;
+}
+
+/* login button on log in page */
+body.sessions-new-page .button.signup {
+	background-color: #2AA2EF;
+	background-image: none;
+	border-color: #2AA2EF;
+	color: #fff;
+	text-shadow: none;
+}
+
+/* remove generic outline from login inputs */
+body.sessions-new-page input:focus,
+body.sessions-new-page button:focus {
+	outline: 0;
+}

--- a/browser.css
+++ b/browser.css
@@ -137,11 +137,33 @@ body.sessions-new-page {
 	text-shadow: none !important;
 }
 
-/* links on login page */
+/* hide header on login page */
+body.sessions-new-page .timeline-head {
+	display: none;
+}
+
+/* add top margin to login form */
+body.sessions-new-page #main_content {
+	min-height: 100%;
+}
+
+/* vertically cetner login form */
+body.sessions-new-page #main_content .signup-body {
+	position: absolute;
+	top: 50%;
+	right: 0;
+	bottom: 50%;
+	left: 0;
+}
+
+body.sessions-new-page #main_content .signup-body form {
+	transform: translateY(-50%);
+}
+
+/* hide links on login page */
 body.sessions-new-page .signup-field-hint,
 body.sessions-new-page .signup-field-hint a:link {
-	color: #2AA2EF;
-	text-shadow: none;
+	display: none;
 }
 
 /* login button on log in page */
@@ -157,4 +179,10 @@ body.sessions-new-page .button.signup {
 body.sessions-new-page input:focus,
 body.sessions-new-page button:focus {
 	outline: 0;
+}
+
+/* hide footer on login page */
+body.sessions-new-page .footer {
+	border: none;
+	display: none;
 }

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -52,8 +52,6 @@ html.dark-mode ._3so04aC4,
 html.dark-mode ._2LwEUgbO,
 html.dark-mode ._3tixQkQf,
 html.dark-mode .KpW0EccK,
-/* login page footer border */
-html.dark-mode body.sessions-new-page .footer,
 /* login page log in button */
 body.sessions-new-page .button.signup,
 html.dark-mode .c2-JCY2V ._222QxFjc ._1BmZ-Yeo {

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -5,6 +5,8 @@ html.dark-mode * {
 
 /* background colours */
 html.dark-mode,
+/* background of login page */
+html.dark-mode body.sessions-new-page,
 /* nav bar */
 html.dark-mode nav,
 /* input box */
@@ -50,6 +52,10 @@ html.dark-mode ._3so04aC4,
 html.dark-mode ._2LwEUgbO,
 html.dark-mode ._3tixQkQf,
 html.dark-mode .KpW0EccK,
+/* login page footer border */
+html.dark-mode body.sessions-new-page .footer,
+/* login page log in button */
+body.sessions-new-page .button.signup,
 html.dark-mode .c2-JCY2V ._222QxFjc ._1BmZ-Yeo {
 	border-color: rgba(255, 255, 255, 0.1) !important;
 }


### PR DESCRIPTION
This is a fix for #70.

This styles the login page to match the style when you log in a little better:

![screen shot 2016-05-27 at 10 04 51 pm](https://cloud.githubusercontent.com/assets/737065/15624538/e79f56c8-2457-11e6-94ca-a7bb4f82e54f.png)
![screen shot 2016-05-27 at 10 04 54 pm](https://cloud.githubusercontent.com/assets/737065/15624539/e79f8dc8-2457-11e6-9a4d-052c72e32bf3.png)
