### PR TITLE
Move OS class creation and darkMode init to after React loads

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -222,10 +222,9 @@ document.addEventListener('DOMContentLoaded', () => {
 	// enable OS specific styles
 	document.documentElement.classList.add(`os-${process.platform}`);
 
+	// activate Dark Mode if it was set before quitting
+	setDarkMode();
+
 	// detect when React is ready before firing init
 	waitFor('#react-root header').then(init);
 });
-
-// activate Dark Mode if it was set before quitting
-// don't wait for React to be ready.
-setDarkMode();


### PR DESCRIPTION
I was getting a couple of console errors and I fixed them by moving some things into the `init()` function which depends on React being ready. Specifically I moved adding the OS-specific class name to the `document`, and I also moved `darkMode()` since that depends on the DOM being ready.

See if you can replicate the errors on `master`, then test this branch. All I did was start the app and it occurred every time.

Errors:

```
/Users/paul/open_source/anatine/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources…:130 Unable to load preload script: /Users/paul/open_source/anatine/browser.js(anonymous function) @ /Users/paul/open_source/anatine/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources…:130
/Users/paul/open_source/anatine/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources…:131 TypeError: Cannot read property 'classList' of null
    at setDarkMode (/Users/paul/open_source/anatine/browser.js:160)
    at Object.<anonymous> (/Users/paul/open_source/anatine/browser.js:231)
    at Module._compile (module.js:541)
    at Object.Module._extensions..js (module.js:550)
    at Module.load (module.js:456)
    at tryModuleLoad (module.js:415)
    at Function.Module._load (module.js:407)
    at Module.require (module.js:466)
    at require (internal/module.js:20)
    at Object.<anonymous> (/Users/paul/open_source/anatine/node_modules/electron-prebuilt/dist/Electron.app/Contents/Resources…:128)
```
