### PR TITLE
Fix listname links; Remove inconsistent link styles

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -238,3 +238,10 @@ body.sessions-new-page .footer {
 	border: none;
 	display: none;
 }
+
+/* remove inconsistent underline on hovering "added to list" list name links */
+._3ZDDth2l:hover,
+/* remove inconsistent underline on hovering username links */
+._2mYajcSS:hover ._2fjPhluv {
+	text-decoration: none !important;
+}

--- a/browser.css
+++ b/browser.css
@@ -239,9 +239,20 @@ body.sessions-new-page .footer {
 	display: none;
 }
 
+/* tweet links are spans in spans in spans */
+._3ZFqFXW8 ._3EzK97M9 > span > span {
+	color: #2AA2EF !important;
+}
+
+/* make "added to list" list name link consistent color */
+._3ZDDth2l {
+	color: inherit !important;
+}
+
 /* remove inconsistent underline on hovering "added to list" list name links */
 ._3ZDDth2l:hover,
 /* remove inconsistent underline on hovering username links */
 ._2mYajcSS:hover ._2fjPhluv {
+	color: inherit !important;
 	text-decoration: none !important;
 }

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -69,7 +69,9 @@ html.dark-mode ._3EzK97M9 > span {
 }
 
 /* tweet links are spans in spans in spans */
-html.dark-mode ._3ZFqFXW8 ._3EzK97M9 > span > span {
+html.dark-mode ._3ZFqFXW8 ._3EzK97M9 > span > span,
+/* "added to list" list name links */
+html.dark-mode ._3ZDDth2l {
 	color: #2AA2EF !important;
 }
 

--- a/dark-mode.css
+++ b/dark-mode.css
@@ -68,13 +68,6 @@ html.dark-mode ._3EzK97M9 > span {
 	color: rgba(255, 255, 255, 0.75);
 }
 
-/* tweet links are spans in spans in spans */
-html.dark-mode ._3ZFqFXW8 ._3EzK97M9 > span > span,
-/* "added to list" list name links */
-html.dark-mode ._3ZDDth2l {
-	color: #2AA2EF !important;
-}
-
 /* user "real name" */
 html.dark-mode ._38kXZCmY,
 /* follower counts */


### PR DESCRIPTION
This fixes #82 and includes a change for username links and the list links.

For the #82 fix, I just added the correct `color` to the link for the list name.

The other thing I changed is to remove the `text-decoration: underline` from usernames on tweets, and from the list name in the notifications. No other in-tweet links (URLs, mentions, or hashtags) has the underline, so it seemed inconsistent. I'm kind of scratching my head why Twitter even has it in there at all.

![new look](https://cloud.githubusercontent.com/assets/737065/15951803/78aae052-2e89-11e6-8b08-2f5d7baf1a80.png)

// cc @SamVerschueren 
