### PR TITLE
scale down profile picture when window is too small - fixes #85

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -56,6 +56,14 @@ img.larrybird {
 	padding-left: 80px !important;
 }
 
+/* scale down the profile picture image in expanded mode and add a padding */
+div._1qcaWNh-._1sp7Rzwo._3tixQkQf > img._1MjUlO8b._3uSDkk5s {
+	box-sizing: border-box;
+	padding: 10px;
+	max-width: 100%;
+	max-height: 100%;
+}
+
 /* make nav bar more narrow */
 #react-root ._2XOZ62oy {
 	height: 2.6rem !important;


### PR DESCRIPTION
I'm not sure about the CSS selectors though. Every element has multiple selectors so I'm not sure which one to pick in order to not brake any CSS for other components. Not sure how react calculates the classnames. I just picked the first ones.
## Before

![anatine-before](https://cloud.githubusercontent.com/assets/1913805/15963695/45d2ba20-2f14-11e6-85c8-f426f21d4dbe.gif)
## After

![anatine-after](https://cloud.githubusercontent.com/assets/1913805/15963696/4abe08be-2f14-11e6-9d29-4f5e53be5ac3.gif)
