### PR TITLE
Fix username and hashtag links being colored

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -240,7 +240,7 @@ body.sessions-new-page .footer {
 }
 
 /* tweet links are spans in spans in spans */
-._3ZFqFXW8 ._3EzK97M9 > span > span {
+._3ZFqFXW8 ._3EzK97M9[dir=ltr] span {
 	color: #2AA2EF !important;
 }
 


### PR DESCRIPTION
The `@` and `#` in username/hashtag links wasn't getting the color applied. This new CSS is a little more general to encompass the symbol and the name/string.
### Before:

![screen shot 2016-06-15 at 10 13 08 pm](https://cloud.githubusercontent.com/assets/737065/16103436/b2481156-3346-11e6-8a12-1fcd359c3617.png)
### After:

![screen shot 2016-06-15 at 10 12 33 pm](https://cloud.githubusercontent.com/assets/737065/16103435/b23f77bc-3346-11e6-982d-0ae0ada41cca.png)

---

Needs a port to `refined-twitter` after it's tested/merged, but it'll be an identical solution ofc.
