### PR TITLE
fix white navigation background

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -29,6 +29,14 @@ html.os-win32 #react-root header .WBlUyLoP {
 	max-width: 800px !important;
 	width: 80% !important;
 }
+#react-root header nav {
+	border-bottom: 1px solid #e1e8ed;
+	background-color: white;
+}
+#react-root header .WBlUyLoP {
+	background-color: transparent;
+	border: none;
+}
 
 /* hide profile link in navbar */
 ._1dNhc0QK > ._3tixQkQf:last-of-type {


### PR DESCRIPTION
Twitter did an update

<img width="340" alt="screen shot 2016-06-28 at 21 02 49" src="https://cloud.githubusercontent.com/assets/1913805/16428772/b35d8940-3d73-11e6-98e2-311383c9c63f.png">

This PR fixes that

<img width="335" alt="screen shot 2016-06-28 at 21 03 16" src="https://cloud.githubusercontent.com/assets/1913805/16428781/c146a94c-3d73-11e6-90db-668bc1301b09.png">
