### PR TITLE
Add keyboard shortcut for lists

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -88,6 +88,11 @@ function registerShortcuts(username) {
 		$(`a[href$="/${username}/likes"]`).click();
 	});
 
+	Mousetrap.bind('g i', () => {
+		$('a[href$="/account"]').click();
+		$(`a[href$="/${username}/lists"]`).click();
+	});
+
 	Mousetrap.bindGlobal('esc', () => {
 		const btn = $('button._158OzO7l');
 


### PR DESCRIPTION
Fixes #93.

Adds a <kbd>g i</kbd> keyboard shortcut for Twitter Lists.

---

Untested, but I can maybe test tonight...

I tried the following code using mobile.twitter.com, and it worked as expected:

``` js
document.querySelector('a[href="/account"]').click()
document.querySelector('a[href="/JosephDykstra/lists"]').click()
```
