### PR TITLE
do not push close button down on reply - fixes #101

### DIFF
--- a/browser.css
+++ b/browser.css
@@ -100,7 +100,7 @@ div._1qcaWNh-._1sp7Rzwo._3tixQkQf > img._1MjUlO8b._3uSDkk5s {
 }
 
 /* push the image close button down so it's not covered by the macOS traffic lights */
-html.os-darwin #react-root ._246HcQqT {
+html.os-darwin #react-root ._1TjEkJ1s ._246HcQqT {
 	margin-top: 30px !important;
 }
 


### PR DESCRIPTION
The `._1TjEkJ1s` selector selects this area

<img width="354" alt="screen shot 2016-07-16 at 12 32 42" src="https://cloud.githubusercontent.com/assets/1913805/16894255/6ebd8218-4b51-11e6-97fa-26156816254c.png">

And seems to be the wrapper around media (video + images). This is also the only place where the `z-index` should be applied that is fixed by #100 
